### PR TITLE
Update to 1.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,9 @@ redmine_issue_tabs
 ==================
 
 Redmine plugin that enhances issue interface by adding several useful tabs: timelog, time spent, code commits, history
+Changelog
+  1.1.1:
+    * fix double tabs in issues page
+  1.1.0:
+    * support Redmine 3.0
+    * fixed rights for timelog page

--- a/app/views/hooks/redmine_issue_tabs/_rm_history_tabs.html.erb
+++ b/app/views/hooks/redmine_issue_tabs/_rm_history_tabs.html.erb
@@ -8,8 +8,10 @@
 <div id="history_tabs">
   <% issue_tabs = [ { name: 'comments', partial: 'redmine_issue_tabs/blank', label: :label_issues_tab_comments },
                     { name: 'history', partial: 'redmine_issue_tabs/blank', label: :label_issues_tab_history },
-                    { name: 'timelog', partial: 'redmine_issue_tabs/timelog', label: :label_spent_time },
-                    { name: 'changesets', partial: 'redmine_issue_tabs/blank', label: :label_associated_revisions } ] %>
-
+                    { name: 'changesets', partial: 'redmine_issue_tabs/blank', label: :label_associated_revisions } ]
+  if User.current.allowed_to?(:view_time_entries, @project)
+    issue_tabs << { name: 'timelog', partial: 'redmine_issue_tabs/timelog', label: :label_spent_time }
+  end
+  %>
   <%= render_tabs issue_tabs %>
 </div>

--- a/app/views/redmine_issue_tabs/_timelog.html.erb
+++ b/app/views/redmine_issue_tabs/_timelog.html.erb
@@ -19,7 +19,7 @@
         <div>
           <b>
             <%= format_date entry.spent_on %>:
-            <%= l_hours entry.hours %></b> &mdash; <%= h entry.activity.name %>.
+            <%= l_hours entry.hours %></b> &mdash; <%= h(entry.activity.try(:name) || 'none') %>.
             <%= authoring entry.created_on, entry.user %>
         </div>
         <div><%= h entry.comments %></div>

--- a/assets/javascripts/issue-history-tabs.js
+++ b/assets/javascripts/issue-history-tabs.js
@@ -26,16 +26,6 @@ RMPlus.TABS = (function (my) {
 })(RMPlus.TABS || {});
 
 $(document).ready(function () {
-  var everythingLoaded = setInterval(function() {
-  if (/loaded|complete|interactive/.test(document.readyState)) {
-    clearInterval(everythingLoaded);
-    if ($('div.tabs li:visible').length <= 1){
-        $('.tabs-buttons').hide();
-        $(window).off("resize", displayTabsButtons);
-      }
-    }
-  }, 100);
-
   var has_comments = false;
   var has_history = ($('.journal').length > 0);
   var has_timelog = ($('#issue_timelog').length > 0);
@@ -91,5 +81,5 @@ $(document).ready(function () {
     $('.tabs a').first().addClass('selected');
   }
 
-  $('.tabs-buttons').hide();
+  $('#history_tabs .tabs-buttons').remove();
 });

--- a/init.rb
+++ b/init.rb
@@ -2,7 +2,7 @@ Redmine::Plugin.register :redmine_issue_tabs do
   name 'Redmine Issue Tabs plugin'
   author 'Pitin Vladimir, Alexey Glukhov'
   description 'Plugin enhances issue interface by adding several useful tabs: timelog, time spent, code commits, history'
-  version '0.0.1'
+  version '1.1.1'
   url 'https://github.com/pineapple-thief/redmine_issue_tabs'
   author_url 'http://example.com/about'
 end

--- a/lib/redmine_issue_tabs/issues_controller_patch.rb
+++ b/lib/redmine_issue_tabs/issues_controller_patch.rb
@@ -1,23 +1,17 @@
 module RedmineIssueTabs
   module IssuesControllerPatch
-    def self.included(base) # :nodoc:
-      base.extend(ClassMethods)
+    def self.included(base)
       base.send(:include, InstanceMethods)
 
       base.class_eval do
         before_filter :get_time_entries, only: [:show]
       end
-
-    end
-
-    module ClassMethods
     end
 
     module InstanceMethods
       def get_time_entries
-        @time_entries = @issue.time_entries.find(:all, :include => [:user, :activity], :order => "#{TimeEntry.table_name}.spent_on DESC")
+        @time_entries = @issue.time_entries.preload(:user, :activity).order("#{TimeEntry.table_name}.spent_on DESC")
       end
-
     end
   end
 end


### PR DESCRIPTION
Changelog
  1.1.1:
    \* fix double tabs in issues page
  1.1.0:
    \* support Redmine 3.0
    \* fixed rights for timelog page
